### PR TITLE
Create a http exception on status code between 400 and 599

### DIFF
--- a/src/main/java/org/weasis/dicom/exception/HttpException.java
+++ b/src/main/java/org/weasis/dicom/exception/HttpException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021 Weasis Team and other contributors.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at http://www.eclipse.org/legal/epl-2.0, or the Apache
+ * License, Version 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package org.weasis.dicom.exception;
+
+import java.io.IOException;
+
+public class HttpException extends IOException {
+  public HttpException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/weasis/dicom/util/ForwardUtil.java
+++ b/src/main/java/org/weasis/dicom/util/ForwardUtil.java
@@ -45,6 +45,7 @@ import org.dcm4che6.net.Association.DataWriter;
 import org.dcm4che6.net.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.weasis.dicom.exception.HttpException;
 import org.weasis.dicom.param.AttributeEditor;
 import org.weasis.dicom.param.AttributeEditorContext;
 import org.weasis.dicom.param.AttributeEditorContext.Abort;
@@ -570,6 +571,9 @@ public class ForwardUtil {
             DicomObject.createFileMetaInformation(p.getCuid(), p.getIuid(), outputTsuid);
         try (InputStream stream = p.getData()) {
           stow.uploadDicom(stream, fmi);
+        } catch (HttpException httpException) {
+          LOGGER.error(httpException.getMessage(), httpException);
+          throw new AbortException(Abort.FILE_EXCEPTION, httpException.getMessage());
         }
       } else {
         AttributeEditorContext context = new AttributeEditorContext(destination);
@@ -602,6 +606,9 @@ public class ForwardUtil {
           } else {
             stow.uploadPayload(preparePlayload(data, outputTsuid, desc, context));
           }
+        } catch (HttpException httpException) {
+          LOGGER.error(httpException.getMessage(), httpException);
+          throw new AbortException(Abort.FILE_EXCEPTION, httpException.getMessage());
         }
         progressNotify(destination, iuid, p.getCuid(), false);
       }
@@ -653,6 +660,9 @@ public class ForwardUtil {
         }
         progressNotify(destination, iuid, p.getCuid(), false);
       }
+    } catch (HttpException httpException) {
+      LOGGER.error(httpException.getMessage(), httpException);
+      throw new AbortException(Abort.FILE_EXCEPTION, httpException.getMessage());
     } catch (AbortException e) {
       progressNotify(destination, iuid, p.getCuid(), true);
       if (e.getAbort() == Abort.CONNECTION_EXCEPTION) {


### PR DESCRIPTION
An http exception is thrown when the code status of the http request is between 400 and 599.
In the ForwardUtil class, this exception is caught, logged and the throws an AbortException of type Abort.FILE_EXCEPTION