### PR TITLE
NullPointerException when the Tag.LUTData is null

### DIFF
--- a/src/main/java/org/dcm4che3/img/DicomImageUtils.java
+++ b/src/main/java/org/dcm4che3/img/DicomImageUtils.java
@@ -142,6 +142,11 @@ public class DicomImageUtils {
         return Optional.empty();
       }
 
+      if (bData == null) {
+      	LOGGER.error("Cannot get byte[] of {}", TagUtils.toString(Tag.LUTData));
+      	return Optional.empty();
+      }
+      
       if (numBits <= 8) { // LUT Data should be stored in 8 bits allocated format
         if (numEntries <= 256 && (bData.length == (numEntries << 1))) {
           // Some implementations have encoded 8 bit entries with 16 bits allocated, padding the


### PR DESCRIPTION
Hello Nicolas, I propose you to make this modification, because we happened to receive a non-standard dicom which contained the tag (0028,3010) and the (0028,3006) was not present. (0028,3006) is of type 1 if (0028,3010) is present. 

It happend in the case when the line 139 bData is null:

bData = dicomLutObject.getBytes(Tag.LUTData); 

So, at line 146 when I do bData.length I get a NullPointerException.

I suggest you add this code to solve the problem.